### PR TITLE
Add Suplidor CRUD interface

### DIFF
--- a/frontend/suplidor/app.js
+++ b/frontend/suplidor/app.js
@@ -1,0 +1,189 @@
+const API_URL = '/api/suplidores';
+let suppliers = [];
+let filtered = [];
+let currentPage = 1;
+const pageSize = 10;
+let map, marker;
+
+const tableBody = document.getElementById('tableBody');
+const pagination = document.getElementById('pagination');
+const searchInput = document.getElementById('searchInput');
+const modal = document.getElementById('modal');
+const deleteModal = document.getElementById('deleteModal');
+const supplierForm = document.getElementById('supplierForm');
+const modalTitle = document.getElementById('modalTitle');
+const closeModalBtn = document.getElementById('closeModal');
+const newBtn = document.getElementById('newBtn');
+const closeDeleteBtn = document.getElementById('closeDelete');
+const confirmDeleteBtn = document.getElementById('confirmDelete');
+let deleteId = null;
+
+async function loadSuppliers() {
+  try {
+    const resp = await fetch(API_URL);
+    suppliers = await resp.json();
+    filtered = suppliers.slice();
+    currentPage = 1;
+    renderTable();
+  } catch (err) {
+    console.error('Error loading suppliers', err);
+  }
+}
+
+function renderTable() {
+  const start = (currentPage - 1) * pageSize;
+  const pageItems = filtered.slice(start, start + pageSize);
+
+  tableBody.innerHTML = pageItems.map(s => `
+    <tr>
+      <td>${s.nombre || ''}</td>
+      <td>${s.ciudad || ''}</td>
+      <td>${s.direccion || ''}</td>
+      <td>${s.email || ''}</td>
+      <td>${(s.telefonos || []).join('<br>')}</td>
+      <td>${s.rNC || ''}</td>
+      <td>${s.nCF || ''}</td>
+      <td>${s.longitud || ''}</td>
+      <td>${s.latitud || ''}</td>
+      <td class="actions">
+        <button class="btn-primary" onclick="openModal('edit', ${s.id})">Editar</button>
+        <button class="btn-primary" onclick="openDelete(${s.id})">Eliminar</button>
+      </td>
+    </tr>`).join('');
+
+  renderPagination();
+}
+
+function renderPagination() {
+  const pageCount = Math.ceil(filtered.length / pageSize) || 1;
+  pagination.innerHTML = '';
+  for (let i = 1; i <= pageCount; i++) {
+    const btn = document.createElement('button');
+    btn.textContent = i;
+    if (i === currentPage) btn.classList.add('active');
+    btn.addEventListener('click', () => { currentPage = i; renderTable(); });
+    pagination.appendChild(btn);
+  }
+}
+
+searchInput.addEventListener('input', () => {
+  const term = searchInput.value.toLowerCase();
+  filtered = suppliers.filter(s =>
+    s.nombre.toLowerCase().includes(term) ||
+    (s.ciudad && s.ciudad.toLowerCase().includes(term))
+  );
+  currentPage = 1;
+  renderTable();
+});
+
+function openModal(mode, id) {
+  supplierForm.reset();
+  supplierForm.id.value = '';
+  modal.style.display = 'flex';
+  modalTitle.textContent = mode === 'create' ? 'Nuevo Suplidor' : 'Editar Suplidor';
+  initMap();
+  if (mode === 'edit') {
+    const s = suppliers.find(x => x.id === id);
+    if (!s) return;
+    supplierForm.id.value = s.id;
+    supplierForm.nombre.value = s.nombre || '';
+    supplierForm.ciudad.value = s.ciudad || '';
+    supplierForm.direccion.value = s.direccion || '';
+    supplierForm.email.value = s.email || '';
+    supplierForm.rnc.value = s.rNC || '';
+    supplierForm.ncf.value = s.nCF || '';
+    supplierForm.telefonos.value = (s.telefonos || []).join(', ');
+    supplierForm.longitud.value = s.longitud || '';
+    supplierForm.latitud.value = s.latitud || '';
+    if (s.latitud && s.longitud) {
+      const latlng = [parseFloat(s.latitud), parseFloat(s.longitud)];
+      map.setView(latlng, 13);
+      if (marker) marker.setLatLng(latlng); else marker = L.marker(latlng).addTo(map);
+    }
+  } else {
+    if (marker) { map.removeLayer(marker); marker = null; }
+    map.setView([18.5, -70], 8);
+  }
+}
+
+function closeModal() {
+  modal.style.display = 'none';
+}
+
+function initMap() {
+  if (!map) {
+    map = L.map('map').setView([18.5, -70], 8);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap'
+    }).addTo(map);
+    map.on('click', function(e) {
+      const { lat, lng } = e.latlng;
+      supplierForm.latitud.value = lat.toFixed(6);
+      supplierForm.longitud.value = lng.toFixed(6);
+      if (marker) { marker.setLatLng(e.latlng); }
+      else { marker = L.marker(e.latlng).addTo(map); }
+    });
+  }
+}
+
+closeModalBtn.addEventListener('click', closeModal);
+newBtn.addEventListener('click', () => openModal('create'));
+
+supplierForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const id = supplierForm.id.value;
+  const data = {
+    nombre: supplierForm.nombre.value,
+    ciudad: supplierForm.ciudad.value,
+    direccion: supplierForm.direccion.value,
+    email: supplierForm.email.value,
+    rNC: supplierForm.rnc.value,
+    nCF: supplierForm.ncf.value,
+    telefonos: supplierForm.telefonos.value ? supplierForm.telefonos.value.split(',').map(t => t.trim()).filter(Boolean) : [],
+    longitud: supplierForm.longitud.value,
+    latitud: supplierForm.latitud.value
+  };
+
+  try {
+    const resp = await fetch(id ? `${API_URL}/${id}` : API_URL, {
+      method: id ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(id ? { ...data, id: parseInt(id) } : data)
+    });
+    if (resp.ok) {
+      await loadSuppliers();
+      closeModal();
+    } else {
+      console.error('Save error', resp.status);
+    }
+  } catch(err) {
+    console.error('Request failed', err);
+  }
+});
+
+function openDelete(id) {
+  deleteId = id;
+  deleteModal.style.display = 'flex';
+}
+
+function closeDelete() {
+  deleteModal.style.display = 'none';
+}
+
+closeDeleteBtn.addEventListener('click', closeDelete);
+
+confirmDeleteBtn.addEventListener('click', async () => {
+  if (!deleteId) return;
+  try {
+    const resp = await fetch(`${API_URL}/${deleteId}`, { method: 'DELETE' });
+    if (resp.ok) {
+      await loadSuppliers();
+      closeDelete();
+    }
+  } catch(err) {
+    console.error('Delete failed', err);
+  }
+});
+
+// initial load
+loadSuppliers();

--- a/frontend/suplidor/index.html
+++ b/frontend/suplidor/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestión de Suplidores - Thelarte</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="hero">
+      <h1>Gestión de Suplidores</h1>
+      <p>Thelarte · Mobiliario</p>
+    </div>
+
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:20px;">
+      <input id="searchInput" class="form-input" placeholder="Buscar por nombre o ciudad" style="max-width:300px;" />
+      <button id="newBtn" class="btn-primary">+ Nuevo Suplidor</button>
+    </div>
+
+    <div class="table-container">
+      <table id="supplierTable">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Ciudad</th>
+            <th>Dirección</th>
+            <th>Email</th>
+            <th>Teléfonos</th>
+            <th>RNC</th>
+            <th>NCF</th>
+            <th>Longitud</th>
+            <th>Latitud</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </div>
+    <div id="pagination" class="pagination"></div>
+  </div>
+
+  <!-- Modal template -->
+  <div id="modal" class="modal-overlay" style="display:none;">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="modalTitle"></h2>
+        <button class="close-btn" id="closeModal">×</button>
+      </div>
+      <form id="supplierForm">
+        <input type="hidden" name="id" />
+        <div class="form-group">
+          <label>Nombre</label>
+          <input type="text" name="nombre" class="form-input" required />
+        </div>
+        <div class="form-group">
+          <label>Ciudad</label>
+          <input type="text" name="ciudad" class="form-input" required />
+        </div>
+        <div class="form-group">
+          <label>Dirección</label>
+          <input type="text" name="direccion" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Email</label>
+          <input type="email" name="email" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>RNC</label>
+          <input type="text" name="rnc" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>NCF</label>
+          <input type="text" name="ncf" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Teléfonos (separados por coma)</label>
+          <input type="text" name="telefonos" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Longitud</label>
+          <input type="text" name="longitud" class="form-input" readonly />
+        </div>
+        <div class="form-group">
+          <label>Latitud</label>
+          <input type="text" name="latitud" class="form-input" readonly />
+        </div>
+        <div class="map-container" id="map"></div>
+        <div style="text-align:right; margin-top:20px;">
+          <button type="submit" class="btn-primary" id="saveBtn">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Delete confirmation -->
+  <div id="deleteModal" class="modal-overlay" style="display:none;">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Confirmar Eliminación</h2>
+        <button class="close-btn" id="closeDelete">×</button>
+      </div>
+      <p>¿Seguro que deseas eliminar este suplidor?</p>
+      <div style="text-align:right; margin-top:20px;">
+        <button id="confirmDelete" class="btn-primary">Eliminar</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/suplidor/styles.css
+++ b/frontend/suplidor/styles.css
@@ -1,0 +1,168 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.container {
+  max-width: 1000px;
+  background: white;
+  border-radius: 20px;
+  box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 40px;
+  margin: auto;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(0,153,99,0.9), rgba(0,153,99,0.7));
+  color: white;
+  padding: 60px;
+  border-radius: 20px 20px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin:-40px -40px 40px;
+}
+
+.btn-primary {
+  background: #009963;
+  color: white;
+  border-radius: 10px;
+  padding: 10px 20px;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.btn-primary:hover {
+  background: #007a4f;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0,153,99,0.4);
+}
+
+.form-input {
+  height: 48px;
+  padding: 12px 16px;
+  border: 2px solid #E5E7EB;
+  border-radius: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #009963;
+  box-shadow: 0 0 0 3px rgba(0,153,99,0.1);
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #009963;
+  color: white;
+}
+
+th, td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.actions button {
+  margin-right: 6px;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.pagination button {
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  margin: 0 2px;
+  cursor: pointer;
+  border-radius: 5px;
+}
+
+.pagination button.active {
+  background: #009963;
+  color: white;
+}
+
+/* Modal styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: white;
+  padding: 20px;
+  border-radius: 20px;
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.modal-header h2 {
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.map-container {
+  height: 300px;
+  margin-top: 10px;
+}
+
+@media (max-width: 600px) {
+  th, td {
+    font-size: 14px;
+  }
+  .btn-primary {
+    padding: 8px 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add new standalone CRUD UI under `frontend/suplidor`
- implement modal forms and map integration with Leaflet
- responsive design with Inter font, custom styles

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68545c7baa688326891594506ea80f60